### PR TITLE
단위테스트 실행 스캐폴드와 CI 워크플로우 추가

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,32 @@
+name: Unit Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+    paths:
+      - "unit-tests/**"
+      - "pintos/devices/timer.c"
+      - ".github/workflows/unit-tests.yml"
+
+jobs:
+  unit-tests:
+    name: unit-tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run unit tests
+        run: python unit-tests/run_local.py

--- a/unit-tests/README.md
+++ b/unit-tests/README.md
@@ -1,0 +1,34 @@
+# Unit Tests (CI/Local)
+
+이 폴더는 Pintos 내부 테스트(`pintos/tests/...`)와 별개인 단위 테스트 모음입니다.
+
+## 목적
+- 구현 계약(Contract)을 빠르게 검증
+- CI/로컬에서 동일한 방식으로 실행
+- OS 의존 최소화 (macOS/Windows 공통)
+
+## 실행 방법
+
+### 공통 (권장)
+```bash
+python3 unit-tests/run_local.py
+```
+
+### macOS/Linux
+```bash
+bash unit-tests/run_local.sh
+```
+
+### Windows (PowerShell)
+```powershell
+powershell -ExecutionPolicy Bypass -File unit-tests/run_local.ps1
+```
+
+## 현재 포함된 테스트
+- `test_timer_sleep_contract.py`
+  - `timer_sleep` 입력 가드(`ticks <= 0`)
+  - `sleep_list` 정렬 삽입 사용 여부
+
+## 범위 원칙
+- 단위테스트는 **현재 구현 완료된 항목만** 검증합니다.
+- 미구현 항목(예: `timer_init` 초기화, `timer_interrupt` wake 루프)은 구현 PR에서 테스트를 확장합니다.

--- a/unit-tests/run_local.ps1
+++ b/unit-tests/run_local.ps1
@@ -1,0 +1,3 @@
+$ErrorActionPreference = "Stop"
+
+python "$PSScriptRoot/run_local.py"

--- a/unit-tests/run_local.py
+++ b/unit-tests/run_local.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+import pathlib
+import subprocess
+import sys
+
+
+def main() -> int:
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    cmd = [
+        sys.executable,
+        "-m",
+        "unittest",
+        "discover",
+        "-s",
+        str(repo_root / "unit-tests"),
+        "-p",
+        "test_*.py",
+        "-v",
+    ]
+    return subprocess.call(cmd, cwd=repo_root)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/unit-tests/run_local.sh
+++ b/unit-tests/run_local.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 "$(dirname "$0")/run_local.py"


### PR DESCRIPTION
## Summary
- 공통 단위테스트 실행 인프라를 `unit-tests/` 폴더에 추가했습니다.
- macOS/Linux(`run_local.sh`)와 Windows(`run_local.ps1`) 로컬 실행 스크립트를 추가했습니다.
- GitHub Actions 워크플로우(`.github/workflows/unit-tests.yml`)를 추가해 PR/메인에서 공통 실행 경로를 마련했습니다.
- 요청대로 테스트 코드 파일은 포함하지 않았습니다.

## Included files
- `.github/workflows/unit-tests.yml`
- `unit-tests/README.md`
- `unit-tests/run_local.py`
- `unit-tests/run_local.sh`
- `unit-tests/run_local.ps1`

## Test plan
- [x] 파일 구성 확인
- [x] 로컬 실행 진입점 확인 (`python3 unit-tests/run_local.py`)

Made with [Cursor](https://cursor.com)